### PR TITLE
Use $(LanguageTargets) to fix MSBuild warnings

### DIFF
--- a/src/Xamarin.Legacy.Sdk/Sdk/Sdk.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Sdk.targets
@@ -1,5 +1,7 @@
 <Project>
+  <PropertyGroup>
+    <LanguageTargets Condition=" $(TargetFramework.StartsWith ('MonoAndroid', StringComparison.OrdinalIgnoreCase)) ">$(MSBuildThisFileDirectory)Xamarin.Legacy.Android.targets</LanguageTargets>
+    <LanguageTargets Condition=" $(TargetFramework.StartsWith ('Xamarin.iOS', StringComparison.OrdinalIgnoreCase)) ">$(MSBuildThisFileDirectory)Xamarin.Legacy.iOS.targets</LanguageTargets>
+  </PropertyGroup>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
-  <Import Condition=" '$(TargetFrameworkIdentifier)' == 'MonoAndroid' " Project="Xamarin.Legacy.Android.targets" />
-  <Import Condition=" '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' " Project="Xamarin.Legacy.iOS.targets" />
 </Project>

--- a/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.Android.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.Android.targets
@@ -12,12 +12,12 @@
     <VsInstallRoot Condition=" '$(VsInstallRoot)' == '' and Exists ('$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Preview/') ">$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Preview/</VsInstallRoot>
     <VsInstallRoot Condition=" '$(VsInstallRoot)' == '' ">$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Enterprise/</VsInstallRoot>
     <TargetFrameworkRootPath>$(VsInstallRoot)Common7/IDE/ReferenceAssemblies/Microsoft/Framework/</TargetFrameworkRootPath>
-    <MSBuildExtensionsPath>$(VsInstallRoot)MSBuild</MSBuildExtensionsPath>
+    <_LegacyExtensionsPath>$(VsInstallRoot)MSBuild</_LegacyExtensionsPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(_FixupsNeeded)' == 'true' and $([MSBuild]::IsOSPlatform ('osx')) ">
     <XamarinAndroidInstallPath Condition=" '$(XamarinAndroidInstallPath)' == '' ">/Library/Frameworks/Xamarin.Android.framework/</XamarinAndroidInstallPath>
     <TargetFrameworkRootPath>$(XamarinAndroidInstallPath)Libraries/xbuild-frameworks/</TargetFrameworkRootPath>
-    <MSBuildExtensionsPath>$(XamarinAndroidInstallPath)Libraries/xbuild</MSBuildExtensionsPath>
+    <_LegacyExtensionsPath>$(XamarinAndroidInstallPath)Libraries/xbuild</_LegacyExtensionsPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(_FixupsNeeded)' == 'true' ">
     <FrameworkPathOverride>$(TargetFrameworkRootPath)MonoAndroid/v1.0/</FrameworkPathOverride>
@@ -29,8 +29,10 @@
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">true</AndroidUseIntermediateDesignerFile>
   </PropertyGroup>
   <Import Sdk="Microsoft.Android.Sdk" Project="../targets/Microsoft.Android.Sdk.DefaultProperties.targets" />
-  <Import Project="$(MSBuildExtensionsPath)/Xamarin/Android/Xamarin.Android.CSharp.targets"   Condition=" '$(IsBindingProject)' != 'true' " />
-  <Import Project="$(MSBuildExtensionsPath)/Xamarin/Android/Xamarin.Android.Bindings.targets" Condition=" '$(IsBindingProject)' == 'true' " />
+  <Import Project="$(_LegacyExtensionsPath)/Xamarin/Android/Xamarin.Android.CSharp.targets"   Condition=" '$(IsBindingProject)' != 'true' and '$(_FixupsNeeded)' == 'true' " />
+  <Import Project="$(_LegacyExtensionsPath)/Xamarin/Android/Xamarin.Android.Bindings.targets" Condition=" '$(IsBindingProject)' == 'true' and '$(_FixupsNeeded)' == 'true' " />
+  <Import Project="$(MSBuildExtensionsPath)/Xamarin/Android/Xamarin.Android.CSharp.targets"   Condition=" '$(IsBindingProject)' != 'true' and '$(_FixupsNeeded)' != 'true' " />
+  <Import Project="$(MSBuildExtensionsPath)/Xamarin/Android/Xamarin.Android.Bindings.targets" Condition=" '$(IsBindingProject)' == 'true' and '$(_FixupsNeeded)' != 'true' " />
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' ">
     <Reference Include="mscorlib"                CopyLocal="false" />
     <Reference Include="Mono.Android"            CopyLocal="false" />

--- a/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.iOS.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.iOS.targets
@@ -12,20 +12,21 @@
     <VsInstallRoot Condition=" '$(VsInstallRoot)' == '' and Exists ('$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Preview/') ">$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Preview/</VsInstallRoot>
     <VsInstallRoot Condition=" '$(VsInstallRoot)' == '' ">$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Enterprise/</VsInstallRoot>
     <TargetFrameworkRootPath>$(VsInstallRoot)Common7/IDE/ReferenceAssemblies/Microsoft/Framework/</TargetFrameworkRootPath>
-    <MSBuildExtensionsPath>$(VsInstallRoot)MSBuild</MSBuildExtensionsPath>
+    <_LegacyExtensionsPath>$(VsInstallRoot)MSBuild</_LegacyExtensionsPath>
     <FrameworkPathOverride>$(TargetFrameworkRootPath)Xamarin.iOS/v1.0/</FrameworkPathOverride>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(_FixupsNeeded)' == 'true' and $([MSBuild]::IsOSPlatform ('osx')) ">
     <MonoPath Condition=" '$(MonoPath)' == '' ">/Library/Frameworks/Mono.framework/</MonoPath>
     <XamariniOSInstallPath Condition=" '$(XamariniOSInstallPath)' == '' ">/Library/Frameworks/Xamarin.iOS.framework/</XamariniOSInstallPath>
     <TargetFrameworkRootPath>$(MonoPath)External/xbuild-frameworks/</TargetFrameworkRootPath>
-    <MSBuildExtensionsPath>$(MonoPath)External/xbuild</MSBuildExtensionsPath>
+    <_LegacyExtensionsPath>$(MonoPath)External/xbuild</_LegacyExtensionsPath>
     <FrameworkPathOverride>$(XamariniOSInstallPath)Versions/Current/lib/mono/Xamarin.iOS/</FrameworkPathOverride>
   </PropertyGroup>
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);IOS</DefineConstants>
   </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)/Xamarin/iOS/Xamarin.iOS.CSharp.targets" />
+  <Import Project="$(_LegacyExtensionsPath)/Xamarin/iOS/Xamarin.iOS.CSharp.targets" Condition=" '$(_FixupsNeeded)' == 'true' " />
+  <Import Project="$(MSBuildExtensionsPath)/Xamarin/iOS/Xamarin.iOS.CSharp.targets" Condition=" '$(_FixupsNeeded)' != 'true' " />
   <ItemGroup Condition=" '$(DisableImplicitFrameworkReferences)' != 'true' ">
     <Reference Include="mscorlib"                CopyLocal="false" />
     <Reference Include="Xamarin.iOS"             CopyLocal="false" />


### PR DESCRIPTION
We currently get lots of warnings such as:

    Xamarin.Android.CSharp.targets(50,5): warning MSB4011: "Microsoft.CSharp.targets" cannot be imported again.
    It was already imported at "Microsoft.NET.Sdk\Sdk\Sdk.targets (37,3)".
    This is most likely a build authoring error. This subsequent import will be ignored.

We can use the same trick as MSBuild.Sdk.Extras:

https://github.com/novotnyllc/MSBuildSdkExtras/blob/7bf8b6484b9fc4df3c10ba96b6722423b0898026/Source/MSBuild.Sdk.Extras/Build/Platforms.targets#L16-L18

If we set `$(LanguageTargets)` instead, this should fix the warning.