### PR TITLE
Fixes for Java binding projects

### DIFF
--- a/samples/JavaBinding/JavaBinding.csproj
+++ b/samples/JavaBinding/JavaBinding.csproj
@@ -2,5 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>monoandroid11.0;net6.0-android</TargetFrameworks>
     <IsBindingProject>true</IsBindingProject>
+    <!-- Hide some warnings -->
+    <NoWarn>CS0108;CS0114;BG8700</NoWarn>
   </PropertyGroup>
 </Project>

--- a/samples/JavaBinding/Transforms/Metadata.xml
+++ b/samples/JavaBinding/Transforms/Metadata.xml
@@ -9,13 +9,7 @@
 	
 	<!-- remove private/internal/implementation/deprecated types -->
 	<remove-node path="/api/package[starts-with(@name, 'com.google.gson.internal')]" />
-
 	<remove-node path="/api/package/class[@visibility='']" />
-	<remove-node path="/api/package/interface[@visibility='']" />
-	<remove-node path="/api/package/class[@deprecated='deprecated']" />
-	<remove-node path="/api/package/interface[@deprecated='deprecated']" />
-	<remove-node path="/api/package/class/method[@deprecated='deprecated']" />
-	<remove-node path="/api/package/interface/method[@deprecated='deprecated']" />
 
 	<attr path="/api/package[@name='com.google.gson']/class[@name='JsonArray']/method[@name='deepCopy' and count(parameter)=0]" name="managedReturn">GoogleGson.JsonElement</attr>
 	<attr path="/api/package[@name='com.google.gson']/class[@name='JsonNull']/method[@name='deepCopy' and count(parameter)=0]" name="managedReturn">GoogleGson.JsonElement</attr>

--- a/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Hacks.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Hacks.targets
@@ -1,0 +1,13 @@
+<!--
+    A collection of "hacks" for both iOS/Android, only imported when $(_FixupsNeeded) is true.
+-->
+<Project>
+  <!-- HACK: $(AssemblySearchPaths) is getting escaped somewhere? -->
+  <Target Name="_FixResolveAssemblyReference"
+      Condition=" '$(_FixupsNeeded)' == 'true' "
+      BeforeTargets="ResolveAssemblyReferences">
+    <PropertyGroup>
+      <AssemblySearchPaths>$([MSBuild]::Unescape($(AssemblySearchPaths)))</AssemblySearchPaths>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.Android.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.Android.targets
@@ -42,4 +42,5 @@
     <Reference Include="System.Numerics.Vectors" CopyLocal="false" />
     <Reference Include="System.Xml"              CopyLocal="false" />
   </ItemGroup>
+  <Import Project="Xamarin.Hacks.targets" Condition=" '$(_FixupsNeeded)' == 'true' " />
 </Project>

--- a/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.iOS.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.iOS.targets
@@ -36,14 +36,6 @@
     <Reference Include="System.Numerics.Vectors" CopyLocal="false" />
     <Reference Include="System.Xml"              CopyLocal="false" />
   </ItemGroup>
-  <!-- HACK: $(AssemblySearchPaths) is getting escaped somewhere? -->
-  <Target Name="_FixResolveAssemblyReference"
-      Condition=" '$(_FixupsNeeded)' == 'true' "
-      BeforeTargets="ResolveAssemblyReferences">
-    <PropertyGroup>
-      <AssemblySearchPaths>$([MSBuild]::Unescape($(AssemblySearchPaths)))</AssemblySearchPaths>
-    </PropertyGroup>
-  </Target>
   <!-- HACK: workaround $(TargetFrameworkDirectory) on macOS -->
   <Target Name="_FixTargetFrameworkDirectory"
       Condition=" '$(_FixupsNeeded)' == 'true' and $([MSBuild]::IsOSPlatform ('osx')) "
@@ -52,4 +44,5 @@
       <TargetFrameworkDirectory>$(FrameworkPathOverride)</TargetFrameworkDirectory>
     </PropertyGroup>
   </Target>
+  <Import Project="Xamarin.Hacks.targets" Condition=" '$(_FixupsNeeded)' == 'true' " />
 </Project>


### PR DESCRIPTION
* Tweak `JavaBinding.csproj` so it emits no warnings. We might
  eventually be able to set `$(TreatWarningsAsErrors)` for samples.
* Move the `_FixResolveAssemblyReference` MSBuild target to a common
  `Xamarin.Hacks.targets`. This fixes missing assembly references for
  `MonoAndroid` TFs.

After doing this, `JavaBinding.csproj` is building correctly with no
warnings.