### PR TITLE
[samples] C# class to verify Java binding

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,8 +9,8 @@ variables:
   DotNet.Cli.Telemetry.OptOut: true
   Android.Msi: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4382031/master/19c3b73163d4d1b3fd940f6ef7908c00595dc7a9/Microsoft.NET.Workload.Android.11.0.200.37.msi
   Android.Pkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4382031/master/19c3b73163d4d1b3fd940f6ef7908c00595dc7a9/Microsoft.NET.Workload.Android-11.0.200-ci.master.37.pkg
-  Xamarin.Android.Vsix: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4382031/master/19c3b73163d4d1b3fd940f6ef7908c00595dc7a9/signed/Xamarin.Android.Sdk-11.2.99.37.vsix
-  Xamarin.Android.Pkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4382031/master/19c3b73163d4d1b3fd940f6ef7908c00595dc7a9/xamarin.android-11.2.99.37.pkg
+  Xamarin.Android.Vsix: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4392253/master/686ccdae98bbaa447aa485b785e51e6d583fd943/signed/Xamarin.Android.Sdk-11.2.99.40.vsix
+  Xamarin.Android.Pkg: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4392253/master/686ccdae98bbaa447aa485b785e51e6d583fd943/xamarin.android-11.2.99.40.pkg
   iOS.Msi: https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/main/3174e94a178c41cae0a51fa296e52f711957c14a/543/package/Microsoft.NET.Workload.iOS.14.2.100-ci.main.30.msi
   iOS.Pkg: https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/main/3174e94a178c41cae0a51fa296e52f711957c14a/543/package/Microsoft.iOS.Bundle.14.2.100-ci.main.30.pkg
 

--- a/samples/JavaBinding/Additions/Foo.cs
+++ b/samples/JavaBinding/Additions/Foo.cs
@@ -1,0 +1,7 @@
+// This is a C# class that won't compile if the Java bindings aren't generated properly
+using System;
+
+class Foo
+{
+    public Type Type => typeof (GoogleGson.Gson);
+}


### PR DESCRIPTION
If the C# bindings aren't generated, the build would fail with:

    Foo.cs(6,33): error CS0246: The type or namespace name 'GoogleGson' could not be found
    (are you missing a using directive or an assembly reference?)