### PR TITLE
[windows] fix for when $(VsInstallRoot) is missing a trailing slash

### DIFF
--- a/samples/samples.sln
+++ b/samples/samples.sln
@@ -7,6 +7,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Hello", "Hello\Hello.csproj
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JavaBinding", "JavaBinding\JavaBinding.csproj", "{67EB8FFE-826F-445A-A8E6-8DAFB3A2E65F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VsInstallRoot", "tests\VsInstallRoot\VsInstallRoot.csproj", "{5B390F99-D000-4DB0-98C4-8FC0F4AC2D9D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{CFDB900E-AD95-43C6-BF87-FEE446EBF78B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{149B3F40-F69B-4A1B-A499-F533B9717040}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,9 +47,26 @@ Global
 		{67EB8FFE-826F-445A-A8E6-8DAFB3A2E65F}.Release|x64.Build.0 = Release|Any CPU
 		{67EB8FFE-826F-445A-A8E6-8DAFB3A2E65F}.Release|x86.ActiveCfg = Release|Any CPU
 		{67EB8FFE-826F-445A-A8E6-8DAFB3A2E65F}.Release|x86.Build.0 = Release|Any CPU
+		{5B390F99-D000-4DB0-98C4-8FC0F4AC2D9D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B390F99-D000-4DB0-98C4-8FC0F4AC2D9D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B390F99-D000-4DB0-98C4-8FC0F4AC2D9D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5B390F99-D000-4DB0-98C4-8FC0F4AC2D9D}.Debug|x64.Build.0 = Debug|Any CPU
+		{5B390F99-D000-4DB0-98C4-8FC0F4AC2D9D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5B390F99-D000-4DB0-98C4-8FC0F4AC2D9D}.Debug|x86.Build.0 = Debug|Any CPU
+		{5B390F99-D000-4DB0-98C4-8FC0F4AC2D9D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B390F99-D000-4DB0-98C4-8FC0F4AC2D9D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B390F99-D000-4DB0-98C4-8FC0F4AC2D9D}.Release|x64.ActiveCfg = Release|Any CPU
+		{5B390F99-D000-4DB0-98C4-8FC0F4AC2D9D}.Release|x64.Build.0 = Release|Any CPU
+		{5B390F99-D000-4DB0-98C4-8FC0F4AC2D9D}.Release|x86.ActiveCfg = Release|Any CPU
+		{5B390F99-D000-4DB0-98C4-8FC0F4AC2D9D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{5E34FB3D-487C-433A-8A49-96444046888D} = {149B3F40-F69B-4A1B-A499-F533B9717040}
+		{67EB8FFE-826F-445A-A8E6-8DAFB3A2E65F} = {149B3F40-F69B-4A1B-A499-F533B9717040}
+		{5B390F99-D000-4DB0-98C4-8FC0F4AC2D9D} = {CFDB900E-AD95-43C6-BF87-FEE446EBF78B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A49B40B9-4E4D-4B19-B124-9B19C41B5759}

--- a/samples/tests/VsInstallRoot/Foo.cs
+++ b/samples/tests/VsInstallRoot/Foo.cs
@@ -1,0 +1,1 @@
+public class Foo { }

--- a/samples/tests/VsInstallRoot/VsInstallRoot.csproj
+++ b/samples/tests/VsInstallRoot/VsInstallRoot.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Xamarin.Legacy.Sdk">
+  <Import Condition=" $([MSBuild]::IsOSPlatform ('windows')) " Project="../../../src/Xamarin.Legacy.Sdk/Sdk/Xamarin.VsInstallRoot.targets" />
+  <PropertyGroup>
+    <TargetFrameworks>monoandroid11.0;xamarin.ios10;net6.0-android;net6.0-ios</TargetFrameworks>
+    <VsInstallRoot Condition=" HasTrailingSlash($(VsInstallRoot)) ">$(VsInstallRoot.TrimEnd ('/').TrimEnd ('\'))</VsInstallRoot>
+  </PropertyGroup>
+</Project>

--- a/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.Android.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.Android.targets
@@ -6,14 +6,10 @@
   <PropertyGroup Condition=" !Exists('$(MSBuildExtensionsPath)/Xamarin/Android/Xamarin.Android.CSharp.targets') ">
     <_FixupsNeeded>true</_FixupsNeeded>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(_FixupsNeeded)' == 'true' and $([MSBuild]::IsOSPlatform ('windows')) ">
-    <VsInstallRoot Condition=" '$(VsInstallRoot)' == '' and '$(VSINSTALLDIR)' != '' ">$(VSINSTALLDIR)</VsInstallRoot>
-    <!-- At the moment 16.9 is in Preview, prefer it -->
-    <VsInstallRoot Condition=" '$(VsInstallRoot)' == '' and Exists ('$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Preview/') ">$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Preview/</VsInstallRoot>
-    <VsInstallRoot Condition=" '$(VsInstallRoot)' == '' ">$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Enterprise/</VsInstallRoot>
-    <TargetFrameworkRootPath>$(VsInstallRoot)Common7/IDE/ReferenceAssemblies/Microsoft/Framework/</TargetFrameworkRootPath>
-    <_LegacyExtensionsPath>$(VsInstallRoot)MSBuild</_LegacyExtensionsPath>
-  </PropertyGroup>
+  <Import
+      Condition=" '$(_FixupsNeeded)' == 'true' and $([MSBuild]::IsOSPlatform ('windows')) "
+      Project="Xamarin.VsInstallRoot.targets"
+  />
   <PropertyGroup Condition=" '$(_FixupsNeeded)' == 'true' and $([MSBuild]::IsOSPlatform ('osx')) ">
     <XamarinAndroidInstallPath Condition=" '$(XamarinAndroidInstallPath)' == '' ">/Library/Frameworks/Xamarin.Android.framework/</XamarinAndroidInstallPath>
     <TargetFrameworkRootPath>$(XamarinAndroidInstallPath)Libraries/xbuild-frameworks/</TargetFrameworkRootPath>

--- a/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.iOS.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.iOS.targets
@@ -6,13 +6,11 @@
   <PropertyGroup Condition=" !Exists('$(MSBuildExtensionsPath)/Xamarin/iOS/Xamarin.iOS.CSharp.targets') ">
     <_FixupsNeeded>true</_FixupsNeeded>
   </PropertyGroup>
+  <Import
+      Condition=" '$(_FixupsNeeded)' == 'true' and $([MSBuild]::IsOSPlatform ('windows')) "
+      Project="Xamarin.VsInstallRoot.targets"
+  />
   <PropertyGroup Condition=" '$(_FixupsNeeded)' == 'true' and $([MSBuild]::IsOSPlatform ('windows')) ">
-    <VsInstallRoot Condition=" '$(VsInstallRoot)' == '' and '$(VSINSTALLDIR)' != '' ">$(VSINSTALLDIR)</VsInstallRoot>
-    <!-- At the moment 16.9 is in Preview, prefer it -->
-    <VsInstallRoot Condition=" '$(VsInstallRoot)' == '' and Exists ('$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Preview/') ">$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Preview/</VsInstallRoot>
-    <VsInstallRoot Condition=" '$(VsInstallRoot)' == '' ">$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Enterprise/</VsInstallRoot>
-    <TargetFrameworkRootPath>$(VsInstallRoot)Common7/IDE/ReferenceAssemblies/Microsoft/Framework/</TargetFrameworkRootPath>
-    <_LegacyExtensionsPath>$(VsInstallRoot)MSBuild</_LegacyExtensionsPath>
     <FrameworkPathOverride>$(TargetFrameworkRootPath)Xamarin.iOS/v1.0/</FrameworkPathOverride>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(_FixupsNeeded)' == 'true' and $([MSBuild]::IsOSPlatform ('osx')) ">

--- a/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.VsInstallRoot.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.VsInstallRoot.targets
@@ -1,0 +1,11 @@
+<!-- This files assumes it is imported on Windows-only -->
+<Project>
+  <PropertyGroup>
+    <VsInstallRoot Condition=" '$(VsInstallRoot)' == '' and '$(VSINSTALLDIR)' != '' ">$(VSINSTALLDIR)</VsInstallRoot>
+    <!-- At the moment 16.9 is in Preview, prefer it -->
+    <VsInstallRoot Condition=" '$(VsInstallRoot)' == '' and Exists ('$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Preview/') ">$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Preview/</VsInstallRoot>
+    <VsInstallRoot Condition=" '$(VsInstallRoot)' == '' ">$(MSBuildProgramFiles32)/Microsoft Visual Studio/2019/Enterprise/</VsInstallRoot>
+    <TargetFrameworkRootPath>$([MSBuild]::EnsureTrailingSlash($(VsInstallRoot)))Common7/IDE/ReferenceAssemblies/Microsoft/Framework/</TargetFrameworkRootPath>
+    <_LegacyExtensionsPath>$([MSBuild]::EnsureTrailingSlash($(VsInstallRoot)))MSBuild</_LegacyExtensionsPath>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Usage of Xamarin.Legacy.Sdk on xamarin-android's CI fails with:

    error MSB4057: The target "_GetRestoreSettingsPerFramework" does not exist in the project.

Reviewing the build logs, `Xamarin.Android.CSharp.targets` fails to be
imported at all due to:

    _LegacyExtensionsPath = C:\Program Files (x86)\Microsoft Visual Studio\2019\EnterpriseMSBuild

It appears that if either `%VSINSTALLDIR%` or `$(VsInstallRoot)` were
missing a trailing slash, then `$(_LegacyExtensionsPath)` would be
incorrect.

First I added a new `samples/tests` folder, to start throwing in
one-off projects as pseudo-unit tests. Or maybe integration tests is a
better term? `dotnet build samples.sln` should be the equivalent of
running tests in this repo.

Next, I moved the `$(VsInstallRoot)` logic to its own
`Xamarin.VsInstallRoot.targets` file to be shared between iOS and
Android.

Lastly, I added the appropriate `EnsureTrailingSlash()` call:

https://docs.microsoft.com/visualstudio/msbuild/property-functions#msbuild-ensuretrailingslash