### PR TITLE
[nuget.config] remove public nuget.org feed

### DIFF
--- a/samples/nuget.config
+++ b/samples/nuget.config
@@ -6,7 +6,6 @@
     <add key="release" value="../bin/Release/" />
     <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
     <add key="xamarin" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/xamarin-impl/nuget/v3/index.json" />
-    <add key="nuget"   value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <config>
     <add key="globalPackagesFolder" value="../packages" />


### PR DESCRIPTION
Context: https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610
Context: https://azure.microsoft.com/en-us/resources/3-ways-to-mitigate-risk-using-private-package-feeds/
Context: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/12676/ncident-help-for-Substitution-attack-risk-from-multiple-package-feeds

There is a Package Substitution Attack inherent in NuGet, whereby
if multiple package sources provide packages with the same name,
it is indeterminate which package source will provide the package.

To fix this repo, we don't actually need `nuget.org` at all.