### PR TITLE
Bump to the builds that shipped in .NET 6 Preview 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ You only need `Xamarin.Legacy.Sdk` if you have a NuGet package that
 needs to target "legacy" Xamarin and .NET 6 *at the same time*.
 
 *NOTE: If you are looking for general information about Xamarin and
-.NET 6. You might start with the [net6-samples][net6-samples] Github
-repository instead.*
+.NET 6. You might start with the [dotnet/net6-mobile-samples][net6-samples]
+Github repository instead.*
 
 Xamarin components like [AndroidX][androidx] or [Google Play
 Services][gps] are prime examples that need to use
@@ -56,7 +56,7 @@ Xamarin.Legacy.Sdk solves this problem by:
   running the existing Xamarin MSBuild tasks & targets under `dotnet
   build`.
 
-[net6-samples]: https://github.com/xamarin/net6-samples
+[net6-samples]: https://github.com/dotnet/net6-mobile-samples
 [androidx]: https://github.com/xamarin/AndroidX
 [gps]: https://github.com/xamarin/GooglePlayServicesComponents
 [type-forwards]: https://docs.microsoft.com/dotnet/standard/assembly/type-forwarding
@@ -78,7 +78,7 @@ You will also need either include a `global.json` with:
 ```json
 {
   "msbuild-sdks": {
-    "Xamarin.Legacy.Sdk": "0.1.0-alpha1"
+    "Xamarin.Legacy.Sdk": "0.1.0-alpha2"
   }
 }
 ```
@@ -86,7 +86,7 @@ You will also need either include a `global.json` with:
 Or specify the version inline:
 
 ```xml
-<Project Sdk="Xamarin.Legacy.Sdk/0.1.0-alpha1">
+<Project Sdk="Xamarin.Legacy.Sdk/0.1.0-alpha2">
 ```
 
 To setup a binding project instead of a class library, simply set

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,21 +17,21 @@ variables:
   - name: Configuration
     value: Release
   - name: DotNetVersion
-    value: 6.0.100-preview.1.21081.5
+    value: 6.0.100-preview.1.21103.13
   - name: DotNet.Cli.Telemetry.OptOut
     value: true
   - name: Android.Msi
-    value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4435786/master/abea285994fb4366de7c6c5e1ae9cc9ee22145dd/Microsoft.NET.Workload.Android.11.0.200.72.msi
+    value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4451481/master/05bb8e0eae11ae6a73838b13cf91ee2433169dff/Microsoft.NET.Workload.Android.11.0.200.85.msi
   - name: Android.Pkg
-    value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4435786/master/abea285994fb4366de7c6c5e1ae9cc9ee22145dd/Microsoft.NET.Workload.Android-11.0.200-ci.master.72.pkg
+    value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/net6/4451481/master/05bb8e0eae11ae6a73838b13cf91ee2433169dff/Microsoft.NET.Workload.Android-11.0.200-ci.master.85.pkg
   - name: Xamarin.Android.Vsix
-    value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4435786/master/abea285994fb4366de7c6c5e1ae9cc9ee22145dd/signed/Xamarin.Android.Sdk-11.2.99.72.vsix
+    value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4451481/master/05bb8e0eae11ae6a73838b13cf91ee2433169dff/signed/Xamarin.Android.Sdk-11.2.99.85.vsix
   - name: Xamarin.Android.Pkg
-    value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4435786/master/abea285994fb4366de7c6c5e1ae9cc9ee22145dd/xamarin.android-11.2.99.72.pkg
+    value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4451481/master/05bb8e0eae11ae6a73838b13cf91ee2433169dff/xamarin.android-11.2.99.85.pkg
   - name: iOS.Msi
-    value: https://bosstoragemirror.azureedge.net/wrench/main/43a294f512d0a68c7b2649c620094a196d6c16f8/4440962/package/Microsoft.NET.Workload.iOS.14.3.100-ci.main.1050.msi
+    value: https://bosstoragemirror.azureedge.net/wrench/main/f01fde5cd9a7ffffcdc8d241200c35988700fa00/4449408/package/Microsoft.NET.Workload.iOS.14.3.100-ci.main.1079.msi
   - name: iOS.Pkg
-    value: https://bosstoragemirror.azureedge.net/wrench/main/43a294f512d0a68c7b2649c620094a196d6c16f8/4440962/package/Microsoft.iOS.Bundle.14.3.100-ci.main.1050.pkg
+    value: https://bosstoragemirror.azureedge.net/wrench/main/f01fde5cd9a7ffffcdc8d241200c35988700fa00/4449408/package/notarized/Microsoft.iOS.Bundle.14.3.100-ci.main.1079.pkg
 
 jobs:
 

--- a/samples/global.json
+++ b/samples/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100-alpha.1.21064.27",
+    "version": "6.0.100-preview.1.21103.13",
     "rollForward": "disable",
     "allowPrerelease": true
   },


### PR DESCRIPTION
Context: https://devblogs.microsoft.com/dotnet/announcing-net-6-preview-1/
Context: https://github.com/dotnet/net6-mobile-samples/releases/tag/6.0.1xx-preview1

Also updated the `README.md` a bit.