### PR TITLE
[nuget] should specify $(PackageType) of MSBuildSdk

### DIFF
--- a/src/Xamarin.Legacy.Sdk/Xamarin.Legacy.Sdk.csproj
+++ b/src/Xamarin.Legacy.Sdk/Xamarin.Legacy.Sdk.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageVersion>0.1.0-alpha2</PackageVersion>
+    <PackageType>MSBuildSdk</PackageType>
     <OutputPath>../../bin/$(Configuration)/</OutputPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
Context: https://docs.microsoft.com/nuget/create-packages/set-package-type
Context: https://github.com/novotnyllc/MSBuildSdkExtras/blob/7bf8b6484b9fc4df3c10ba96b6722423b0898026/Tools/MSBuild.Packaging.targets#L4

Xamarin.Legacy.Sdk needs to specify its NuGet package type.