### PR TITLE
[azdo] fix signing tasks

### DIFF
--- a/src/Xamarin.Legacy.Sdk/SignList.xml
+++ b/src/Xamarin.Legacy.Sdk/SignList.xml
@@ -1,0 +1,8 @@
+<Project>
+  <!--
+  NOTE: if this package ever has .dll files:
+  <ItemGroup>
+    <FirstParty Include="Xamarin.Legacy.Sdk.dll" />
+  </ItemGroup>
+  -->
+</Project>

--- a/src/Xamarin.Legacy.Sdk/Xamarin.Legacy.Sdk.csproj
+++ b/src/Xamarin.Legacy.Sdk/Xamarin.Legacy.Sdk.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <None Include="../../LICENSE" Pack="true" PackagePath="/" />
     <None Update="@(None)" Pack="true" PackagePath="/" />
+    <None Update="SignList.xml" Pack="false" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <Target Name="_ClearNuGetCache" BeforeTargets="Build">
     <RemoveDir Directories="$(MSBuildThisFileDirectory)../../packages/xamarin.legacy.sdk/" />


### PR DESCRIPTION
It appears that the .yaml template I use for signing expects at least
a `SignList.xml` now:

    Get-Content : Cannot find path 'C:\A\1\_temp\artifact-signing\unsigned\nuget-unsigned\SignList.xml' because it does not exist.

This repo is unique because there are not actually any `.dll` files to
sign. The NuGet package is only `.targets` files.

For now, I've added a `SignList.xml` with no items. If I ever add a
`.dll` file one day, I'll have an example to follow.