### PR TITLE
[build] don't run signing stage on PRs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,3 +147,4 @@ jobs:
     displayName: sign
     artifactName: nuget-unsigned
     dependsOn: windows
+    condition: ne(variables['Build.Reason'], 'PullRequest')


### PR DESCRIPTION
This was useful initially to "test sign" PRs, but probably don't need this running on PRs anymore.