### PR TITLE
[ios] disable remote builds

### DIFF
--- a/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.iOS.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.iOS.targets
@@ -42,5 +42,10 @@
       <TargetFrameworkDirectory>$(FrameworkPathOverride)</TargetFrameworkDirectory>
     </PropertyGroup>
   </Target>
+  <Target Name="_DisableRemoteBuilds" AfterTargets="EvaluateRemoteBuild">
+    <PropertyGroup>
+      <IsRemoteBuild Condition=" '$(IsRemoteBuild)' == 'true' ">false</IsRemoteBuild>
+    </PropertyGroup>
+  </Target>
   <Import Project="Xamarin.Hacks.targets" Condition=" '$(_FixupsNeeded)' == 'true' " />
 </Project>


### PR DESCRIPTION
Remote builds always seem to fail under .NET framework MSBuild with:

    C:\Program Files\dotnet\packs\Microsoft.iOS.Windows.Sdk\14.5.100-preview.4.638\tools\msbuild\iOS\Xamarin.Messaging.Build.targets(109,7): error MSB4064: The "ServerPort" parameter is not supported by the "SayHello" task loaded from assembly: Xamarin.iOS.Tasks, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null from the path: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\iOS\Xamarin.iOS.Tasks.dll. Verify that the parameter exists on the task, the <UsingTask> points to the correct assembly, and it is a settable public instance property.

Let's try disabling remote builds completely.