### PR TITLE
[build] provision Xamarin.Android from .NET 6 release branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,10 @@ variables:
     value: true
   - name: DotNet.Workloads
     value: microsoft-android-sdk-full microsoft-ios-sdk-full microsoft-macos-sdk-full
+  - name: Xamarin.Android.Vsix
+    value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4948326/6.0.1xx-preview6/9a7da6d3e943544abbf67758b50fd5afb21875cc/signed/Xamarin.Android.Sdk-11.4.99.30.vsix
+  - name: Xamarin.Android.Pkg
+    value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4948326/6.0.1xx-preview6/9a7da6d3e943544abbf67758b50fd5afb21875cc/xamarin.android-11.4.99.30.pkg
 
 jobs:
 
@@ -43,7 +47,7 @@ jobs:
     displayName: install .NET workloads
   - powershell: |
       & dotnet tool update --global boots --version $(BootsVersion)
-      & boots --preview Xamarin.Android
+      & boots $(Xamarin.Android.Vsix)
     displayName: install Xamarin.Android
   - script: dotnet build Xamarin.Legacy.Sdk.sln -bl:$(System.DefaultWorkingDirectory)/bin/Xamarin.Legacy.Sdk.binlog
     displayName: build SDK
@@ -80,7 +84,7 @@ jobs:
     displayName: install .NET workloads
   - powershell: |
       & dotnet tool update --global boots --version $(BootsVersion)
-      & boots --preview Xamarin.Android
+      & boots $(Xamarin.Android.Vsix)
     displayName: install Xamarin.Android
   - task: MSBuild@1
     inputs:
@@ -120,7 +124,7 @@ jobs:
     displayName: install .NET workloads
   - bash: >
       dotnet tool update --global boots --version $(BootsVersion) &&
-      boots --preview Xamarin.Android
+      boots $(Xamarin.Android.Pkg)
     displayName: install Xamarin.Android
   - script: dotnet build Xamarin.Legacy.Sdk.sln -bl:$(System.DefaultWorkingDirectory)/bin/Xamarin.Legacy.Sdk.binlog
     displayName: build SDK


### PR DESCRIPTION
Otherwise we hit errors such as:

    Xamarin.Android.Tooling.targets(70,9): error MSB4064: The "MinimumSupportedJavaVersion" parameter is not supported by the "ResolveSdks" task loaded from assembly: Xamarin.Android.Build.Tasks, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null from the path: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Xamarin\Android\Xamarin.Android.Build.Tasks.dll. Verify that the parameter exists on the task, the <UsingTask> points to the correct assembly, and it is a settable public instance property.
    Xamarin.Android.Tooling.targets(64,5): error MSB4063: The "ResolveSdks" task could not be initialized with its input parameters.

This issue will be properly resolved when we strong name all assemblies.