### PR TITLE
[build] use .NET 6 Preview 7 and test workload.json file

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,7 @@ variables:
   - name: Configuration
     value: Release
   - name: DotNetVersion
-    value: 6.0.100-preview.5.21302.13
+    value: 6.0.100-preview.7.21377.35
   - name: BootsVersion
     value: 1.0.4.624
   - name: DotNet.Cli.Telemetry.OptOut
@@ -43,6 +43,7 @@ jobs:
       & dotnet --list-sdks
     displayName: install .NET $(DotNetVersion)
   - powershell: |
+      & dotnet workload update --print-rollback > .\bin\workload.json
       & dotnet workload install $(DotNet.Workloads) --verbosity diag
     displayName: install .NET workloads
   - powershell: |
@@ -80,6 +81,7 @@ jobs:
       & dotnet --list-sdks
     displayName: install .NET $(DotNetVersion)
   - powershell: |
+      & dotnet workload update --print-rollback > .\bin\workload.json
       & dotnet workload install $(DotNet.Workloads) --verbosity diag
     displayName: install .NET workloads
   - powershell: |
@@ -120,7 +122,9 @@ jobs:
       dotnet --list-sdks &&
       echo "##vso[task.setvariable variable=PATH]$PATH"
     displayName: install .NET $(DotNetVersion)
-  - bash: dotnet workload install $(DotNet.Workloads) --verbosity diag
+  - bash: >
+      dotnet workload update --print-rollback > ./bin/workload.json && 
+      dotnet workload install $(DotNet.Workloads) --verbosity diag
     displayName: install .NET workloads
   - bash: >
       dotnet tool update --global boots --version $(BootsVersion) &&

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,9 +47,7 @@ jobs:
       & dotnet --list-sdks
     displayName: install .NET $(DotNetVersion)
   - powershell: |
-      & dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --verbosity diag
-      mkdir $(System.DefaultWorkingDirectory)\bin\
-      & dotnet workload update --print-rollback > $(System.DefaultWorkingDirectory)\bin\workload.json
+      & dotnet workload update --from-rollback-file workload.json
     displayName: install .NET workloads
   - powershell: |
       & dotnet tool update --global boots --version $(BootsVersion)
@@ -86,9 +84,7 @@ jobs:
       & dotnet --list-sdks
     displayName: install .NET $(DotNetVersion)
   - powershell: |
-      & dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --verbosity diag
-      mkdir $(System.DefaultWorkingDirectory)\bin\
-      & dotnet workload update --print-rollback > $(System.DefaultWorkingDirectory)\bin\workload.json
+      & dotnet workload update --from-rollback-file workload.json
     displayName: install .NET workloads
   - powershell: |
       & dotnet tool update --global boots --version $(BootsVersion)
@@ -128,10 +124,7 @@ jobs:
       dotnet --list-sdks &&
       echo "##vso[task.setvariable variable=PATH]$PATH"
     displayName: install .NET $(DotNetVersion)
-  - bash: >
-      dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --verbosity diag &&
-      mkdir $(System.DefaultWorkingDirectory)/bin &&
-      dotnet workload update --print-rollback > $(System.DefaultWorkingDirectory)/bin/workload.json
+  - bash: dotnet workload update --from-rollback-file workload.json
     displayName: install .NET workloads
   - bash: >
       dotnet tool update --global boots --version $(BootsVersion) &&

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,7 @@ jobs:
       & dotnet --list-sdks
     displayName: install .NET $(DotNetVersion)
   - powershell: |
+      mkdir .\bin\
       & dotnet workload update --print-rollback > .\bin\workload.json
       & dotnet workload install $(DotNet.Workloads) --verbosity diag
     displayName: install .NET workloads
@@ -81,6 +82,7 @@ jobs:
       & dotnet --list-sdks
     displayName: install .NET $(DotNetVersion)
   - powershell: |
+      mkdir .\bin\
       & dotnet workload update --print-rollback > .\bin\workload.json
       & dotnet workload install $(DotNet.Workloads) --verbosity diag
     displayName: install .NET workloads
@@ -123,7 +125,8 @@ jobs:
       echo "##vso[task.setvariable variable=PATH]$PATH"
     displayName: install .NET $(DotNetVersion)
   - bash: >
-      dotnet workload update --print-rollback > ./bin/workload.json && 
+      mkdir bin &&
+      dotnet workload update --print-rollback > bin/workload.json && 
       dotnet workload install $(DotNet.Workloads) --verbosity diag
     displayName: install .NET workloads
   - bash: >

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,9 +47,9 @@ jobs:
       & dotnet --list-sdks
     displayName: install .NET $(DotNetVersion)
   - powershell: |
+      & dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --verbosity diag
       mkdir $(System.DefaultWorkingDirectory)\bin\
       & dotnet workload update --print-rollback > $(System.DefaultWorkingDirectory)\bin\workload.json
-      & dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --verbosity diag
     displayName: install .NET workloads
   - powershell: |
       & dotnet tool update --global boots --version $(BootsVersion)
@@ -86,9 +86,9 @@ jobs:
       & dotnet --list-sdks
     displayName: install .NET $(DotNetVersion)
   - powershell: |
+      & dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --verbosity diag
       mkdir $(System.DefaultWorkingDirectory)\bin\
       & dotnet workload update --print-rollback > $(System.DefaultWorkingDirectory)\bin\workload.json
-      & dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --verbosity diag
     displayName: install .NET workloads
   - powershell: |
       & dotnet tool update --global boots --version $(BootsVersion)
@@ -129,9 +129,9 @@ jobs:
       echo "##vso[task.setvariable variable=PATH]$PATH"
     displayName: install .NET $(DotNetVersion)
   - bash: >
+      dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --verbosity diag &&
       mkdir $(System.DefaultWorkingDirectory)/bin &&
-      dotnet workload update --print-rollback > $(System.DefaultWorkingDirectory)/bin/workload.json && 
-      dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --verbosity diag
+      dotnet workload update --print-rollback > $(System.DefaultWorkingDirectory)/bin/workload.json
     displayName: install .NET workloads
   - bash: >
       dotnet tool update --global boots --version $(BootsVersion) &&

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,8 @@ jobs:
       & dotnet --list-sdks
     displayName: install .NET $(DotNetVersion)
   - powershell: |
-      & dotnet workload update --from-rollback-file workload.json
+      & dotnet workload update --from-rollback-file workload.json --verbosity diag
+      & dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --skip-manifest-update --verbosity diag
     displayName: install .NET workloads
   - powershell: |
       & dotnet tool update --global boots --version $(BootsVersion)
@@ -84,7 +85,8 @@ jobs:
       & dotnet --list-sdks
     displayName: install .NET $(DotNetVersion)
   - powershell: |
-      & dotnet workload update --from-rollback-file workload.json
+      & dotnet workload update --from-rollback-file workload.json --verbosity diag
+      & dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --skip-manifest-update --verbosity diag
     displayName: install .NET workloads
   - powershell: |
       & dotnet tool update --global boots --version $(BootsVersion)
@@ -124,7 +126,9 @@ jobs:
       dotnet --list-sdks &&
       echo "##vso[task.setvariable variable=PATH]$PATH"
     displayName: install .NET $(DotNetVersion)
-  - bash: dotnet workload update --from-rollback-file workload.json
+  - bash: >
+      dotnet workload update --from-rollback-file workload.json --verbosity diag &&
+      dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --skip-manifest-update --verbosity diag
     displayName: install .NET workloads
   - bash: >
       dotnet tool update --global boots --version $(BootsVersion) &&

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,8 @@ variables:
     value: true
   - name: DotNet.Workloads
     value: android ios macos
+  - name: DotNet.Workload.Feeds
+    value: --source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json --source https://aka.ms/maui-preview/index.json
   - name: Xamarin.Android.Vsix
     value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4948326/6.0.1xx-preview6/9a7da6d3e943544abbf67758b50fd5afb21875cc/signed/Xamarin.Android.Sdk-11.4.99.30.vsix
   - name: Xamarin.Android.Pkg
@@ -45,7 +47,7 @@ jobs:
   - powershell: |
       mkdir $(System.DefaultWorkingDirectory)\bin\
       & dotnet workload update --print-rollback > $(System.DefaultWorkingDirectory)\bin\workload.json
-      & dotnet workload install $(DotNet.Workloads) --verbosity diag
+      & dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --verbosity diag
     displayName: install .NET workloads
   - powershell: |
       & dotnet tool update --global boots --version $(BootsVersion)
@@ -84,7 +86,7 @@ jobs:
   - powershell: |
       mkdir $(System.DefaultWorkingDirectory)\bin\
       & dotnet workload update --print-rollback > $(System.DefaultWorkingDirectory)\bin\workload.json
-      & dotnet workload install $(DotNet.Workloads) --verbosity diag
+      & dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --verbosity diag
     displayName: install .NET workloads
   - powershell: |
       & dotnet tool update --global boots --version $(BootsVersion)
@@ -127,7 +129,7 @@ jobs:
   - bash: >
       mkdir $(System.DefaultWorkingDirectory)/bin &&
       dotnet workload update --print-rollback > $(System.DefaultWorkingDirectory)/bin/workload.json && 
-      dotnet workload install $(DotNet.Workloads) --verbosity diag
+      dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --verbosity diag
     displayName: install .NET workloads
   - bash: >
       dotnet tool update --global boots --version $(BootsVersion) &&

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ variables:
   - name: DotNet.Cli.Telemetry.OptOut
     value: true
   - name: DotNet.Workloads
-    value: microsoft-android-sdk-full microsoft-ios-sdk-full microsoft-macos-sdk-full
+    value: android ios macos
   - name: Xamarin.Android.Vsix
     value: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4948326/6.0.1xx-preview6/9a7da6d3e943544abbf67758b50fd5afb21875cc/signed/Xamarin.Android.Sdk-11.4.99.30.vsix
   - name: Xamarin.Android.Pkg

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,8 +43,8 @@ jobs:
       & dotnet --list-sdks
     displayName: install .NET $(DotNetVersion)
   - powershell: |
-      mkdir .\bin\
-      & dotnet workload update --print-rollback > .\bin\workload.json
+      mkdir $(System.DefaultWorkingDirectory)\bin\
+      & dotnet workload update --print-rollback > $(System.DefaultWorkingDirectory)\bin\workload.json
       & dotnet workload install $(DotNet.Workloads) --verbosity diag
     displayName: install .NET workloads
   - powershell: |
@@ -82,8 +82,8 @@ jobs:
       & dotnet --list-sdks
     displayName: install .NET $(DotNetVersion)
   - powershell: |
-      mkdir .\bin\
-      & dotnet workload update --print-rollback > .\bin\workload.json
+      mkdir $(System.DefaultWorkingDirectory)\bin\
+      & dotnet workload update --print-rollback > $(System.DefaultWorkingDirectory)\bin\workload.json
       & dotnet workload install $(DotNet.Workloads) --verbosity diag
     displayName: install .NET workloads
   - powershell: |
@@ -125,8 +125,8 @@ jobs:
       echo "##vso[task.setvariable variable=PATH]$PATH"
     displayName: install .NET $(DotNetVersion)
   - bash: >
-      mkdir bin &&
-      dotnet workload update --print-rollback > bin/workload.json && 
+      mkdir $(System.DefaultWorkingDirectory)/bin &&
+      dotnet workload update --print-rollback > $(System.DefaultWorkingDirectory)/bin/workload.json && 
       dotnet workload install $(DotNet.Workloads) --verbosity diag
     displayName: install .NET workloads
   - bash: >

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,8 +18,6 @@ variables:
     value: Release
   - name: DotNetVersion
     value: 6.0.100-preview.7.21377.35
-  - name: DotNet.Skip.First.Time.Experience
-    value: 1
   - name: BootsVersion
     value: 1.0.4.624
   - name: DotNet.Cli.Telemetry.OptOut
@@ -47,7 +45,7 @@ jobs:
       & dotnet --list-sdks
     displayName: install .NET $(DotNetVersion)
   - powershell: |
-      & dotnet workload update --from-rollback-file workload.json --verbosity diag
+      & dotnet workload update $(DotNet.Workload.Feeds) --from-rollback-file workload.json --verbosity diag
       & dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --skip-manifest-update --verbosity diag
     displayName: install .NET workloads
   - powershell: |
@@ -85,7 +83,7 @@ jobs:
       & dotnet --list-sdks
     displayName: install .NET $(DotNetVersion)
   - powershell: |
-      & dotnet workload update --from-rollback-file workload.json --verbosity diag
+      & dotnet workload update $(DotNet.Workload.Feeds) --from-rollback-file workload.json --verbosity diag
       & dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --skip-manifest-update --verbosity diag
     displayName: install .NET workloads
   - powershell: |
@@ -127,7 +125,7 @@ jobs:
       echo "##vso[task.setvariable variable=PATH]$PATH"
     displayName: install .NET $(DotNetVersion)
   - bash: >
-      dotnet workload update --from-rollback-file workload.json --verbosity diag &&
+      dotnet workload update $(DotNet.Workload.Feeds) --from-rollback-file workload.json --verbosity diag &&
       dotnet workload install $(DotNet.Workloads) $(DotNet.Workload.Feeds) --skip-manifest-update --verbosity diag
     displayName: install .NET workloads
   - bash: >

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,8 @@ variables:
     value: Release
   - name: DotNetVersion
     value: 6.0.100-preview.7.21377.35
+  - name: DotNet.Skip.First.Time.Experience
+    value: 1
   - name: BootsVersion
     value: 1.0.4.624
   - name: DotNet.Cli.Telemetry.OptOut

--- a/workload.json
+++ b/workload.json
@@ -1,0 +1,10 @@
+{
+    "microsoft.net.sdk.tvos": "15.0.100-preview.7219",
+    "microsoft.net.sdk.android": "30.0.100-preview.7.105",
+    "microsoft.net.sdk.maui": "6.0.100-preview.7.1116",
+    "microsoft.net.sdk.macos": "12.0.100-preview.7219",
+    "microsoft.net.workload.emscripten": "6.0.0-rc.1.21378.1",
+    "microsoft.net.sdk.maccatalyst": "15.0.100-preview.7219",
+    "microsoft.net.sdk.ios": "15.0.100-preview.7219",
+    "microsoft.net.workload.mono.toolchain": "6.0.0-rc.1.21378.7"
+}


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/pull/18654

With .NET 6 Preview 7, we might have a way to "pin" workload versions.

This tests that out by doing:

    dotnet workload update --print-rollback > workload.json

Save the file somewhere.

Then we can run:

    dotnet workload update --from-rollback workload.json