### PR TITLE
Fixes to support C# 10 global using

### DIFF
--- a/src/Xamarin.Legacy.Sdk/Sdk/Sdk.props
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Sdk.props
@@ -4,5 +4,4 @@
     <XamarinLegacySdk>true</XamarinLegacySdk>
   </PropertyGroup>
   <Import Sdk="Microsoft.NET.Sdk"     Project="Sdk.props" />
-  <Import Condition=" '$(TargetFrameworkIdentifier)' == 'MonoAndroid' " Sdk="Microsoft.Android.Sdk" Project="AutoImport.props" />
 </Project>

--- a/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.Android.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.Android.targets
@@ -22,6 +22,7 @@
     <DefineConstants>$(DefineConstants);ANDROID</DefineConstants>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
     <OutputPath Condition=" '$(OutputPath)' == '' ">$(BaseOutputPath)$(Configuration)</OutputPath>
+    <TargetPlatformIdentifier>Android</TargetPlatformIdentifier>
     <EnableDefaultAndroidItems Condition=" '$(EnableDefaultAndroidItems)' == '' ">true</EnableDefaultAndroidItems>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">true</AndroidUseIntermediateDesignerFile>
   </PropertyGroup>

--- a/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.iOS.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.iOS.targets
@@ -23,6 +23,8 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);IOS</DefineConstants>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
+    <TargetPlatformIdentifier>iOS</TargetPlatformIdentifier>
+    <EnableDefaultiOSItems Condition=" '$(EnableDefaultiOSItems)' == '' ">true</EnableDefaultiOSItems>
   </PropertyGroup>
   <Import Project="$(_LegacyExtensionsPath)/Xamarin/iOS/Xamarin.iOS.CSharp.targets" Condition=" '$(_FixupsNeeded)' == 'true' " />
   <Import Project="$(MSBuildExtensionsPath)/Xamarin/iOS/Xamarin.iOS.CSharp.targets" Condition=" '$(_FixupsNeeded)' != 'true' " />


### PR DESCRIPTION
We are defining global usings in the mobile workloads
`AutoImports.props` such as:

    <ItemGroup Condition=" '$(TargetPlatformIdentifier)' == 'android' and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
      <Using Include="Android.App" />
      <Using Include="Android.Widget" />
      <Using Include="Android.OS.Bundle" Alias="Bundle" />
    </ItemGroup>

So we should simply define `$(TargetPlatformIdentifier)` and this will
work for iOS and Android.

I found the import here actually never worked:

    <Import Condition=" '$(TargetFrameworkIdentifier)' == 'MonoAndroid' " Sdk="Microsoft.Android.Sdk" Project="AutoImport.props" />

`$(TargetFrameworkIdentifier)` is always blank. The reason it worked
at all, was because Xamarin.Legacy.Sdk defines:

    <EnableDefaultAndroidItems Condition=" '$(EnableDefaultAndroidItems)' == '' ">true</EnableDefaultAndroidItems>

So let's add this to the iOS side.