### PR TITLE
[build] remove workaround for .NET 6 preview 7

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <!-- Workaround issue with .NET 6.0.100-preview.7.21379.14 and VS MSBuild -->
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-  </PropertyGroup>
-</Project>


### PR DESCRIPTION
`$(DisableImplicitNamespaceImports)` is no longer needed.