### PR TITLE
[Android] add support for AutoImport.props across .NET versions

### DIFF
--- a/src/Xamarin.Legacy.Sdk/Sdk/AutoImport.Android.props
+++ b/src/Xamarin.Legacy.Sdk/Sdk/AutoImport.Android.props
@@ -1,0 +1,36 @@
+<!--
+An implementation of xamarin-android's AutoImport.props
+NOTE! everything must be conditioned behind:
+'$(TargetPlatformIdentifier)' == 'android' or $(TargetFramework.StartsWith ('MonoAndroid', StringComparison.OrdinalIgnoreCase))
+-->
+<Project>
+  <ItemGroup Condition=" ('$(TargetPlatformIdentifier)' == 'android' or $(TargetFramework.StartsWith ('MonoAndroid', StringComparison.OrdinalIgnoreCase))) and ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable') ">
+    <Using Include="Android.App" Platform="Android" Sdk="Xamarin.Legacy.Sdk" />
+    <Using Include="Android.Widget" Platform="Android" Sdk="Xamarin.Legacy.Sdk" />
+    <Using Include="Android.OS.Bundle" Alias="Bundle" Platform="Android" Sdk="Xamarin.Legacy.Sdk" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" ('$(TargetPlatformIdentifier)' == 'android' or $(TargetFramework.StartsWith ('MonoAndroid', StringComparison.OrdinalIgnoreCase))) and '$(EnableDefaultXamarinLegacySdkItems)' == 'true' ">
+    <!-- Default Resource file inclusion -->
+    <!-- https://developer.android.com/guide/topics/resources/providing-resources -->
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.xml" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.axml" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.png" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.jpg" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.gif" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.ttf" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.otf" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.ttc" />
+    <AndroidResource Include="$(MonoAndroidResourcePrefix)\raw\*" Exclude="$(MonoAndroidResourcePrefix)\raw\.*" />
+    <!-- Default Asset file inclusion -->
+    <AndroidAsset Include="$(MonoAndroidAssetsPrefix)\**\*" Exclude="$(MonoAndroidAssetsPrefix)\**\.*\**" />
+    <!-- Default XPath transforms for bindings -->
+    <TransformFile Include="Transforms*.xml" />
+    <TransformFile Include="Transforms\**\*.xml" />
+    <!-- Default Java or native libraries -->
+    <AndroidLibrary       Include="**\*.jar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder);**\*-source.jar;**\*-sources.jar;**\*-src.jar" />
+    <AndroidLibrary       Include="**\*.aar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <AndroidNativeLibrary Include="**\*.so"  Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+    <JavaSourceJar        Include="**\*-source.jar;**\*-sources.jar;**\*-src.jar" Exclude="$(DefaultItemExcludes);$(DefaultExcludesInProjectFolder)" />
+  </ItemGroup>
+</Project>

--- a/src/Xamarin.Legacy.Sdk/Sdk/Sdk.props
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Sdk.props
@@ -4,4 +4,5 @@
     <XamarinLegacySdk>true</XamarinLegacySdk>
   </PropertyGroup>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+  <Import Project="AutoImport.Android.props" />
 </Project>

--- a/src/Xamarin.Legacy.Sdk/Sdk/Sdk.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Sdk.targets
@@ -3,6 +3,8 @@
     <LanguageTargets Condition=" $(TargetFramework.StartsWith ('MonoAndroid', StringComparison.OrdinalIgnoreCase)) ">$(MSBuildThisFileDirectory)Xamarin.Legacy.Android.targets</LanguageTargets>
     <LanguageTargets Condition=" $(TargetFramework.StartsWith ('Xamarin.iOS', StringComparison.OrdinalIgnoreCase)) ">$(MSBuildThisFileDirectory)Xamarin.Legacy.iOS.targets</LanguageTargets>
     <LanguageTargets Condition=" $(TargetFramework.StartsWith ('XamarinMac', StringComparison.OrdinalIgnoreCase)) ">$(MSBuildThisFileDirectory)Xamarin.Legacy.macOS.targets</LanguageTargets>
+    <EnableDefaultAndroidItems Condition=" '$(EnableDefaultAndroidItems)' == '' ">false</EnableDefaultAndroidItems>
+    <EnableDefaultXamarinLegacySdkItems Condition=" '$(EnableDefaultXamarinLegacySdkItems)' == '' ">true</EnableDefaultXamarinLegacySdkItems>
   </PropertyGroup>
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
 </Project>

--- a/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.Android.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.Android.targets
@@ -23,7 +23,6 @@
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
     <OutputPath Condition=" '$(OutputPath)' == '' ">$(BaseOutputPath)$(Configuration)</OutputPath>
     <TargetPlatformIdentifier>Android</TargetPlatformIdentifier>
-    <EnableDefaultAndroidItems Condition=" '$(EnableDefaultAndroidItems)' == '' ">true</EnableDefaultAndroidItems>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">true</AndroidUseIntermediateDesignerFile>
   </PropertyGroup>
   <Import Sdk="Microsoft.Android.Sdk" Project="../targets/Microsoft.Android.Sdk.DefaultProperties.targets" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/7023

In order to support `AutoImport.props` across multiple versions of the
Android workload in .NET 6 and .NET 7, we have to condition
`AutoImport.props` behind:

    Condition=" '$(TargetPlatformIdentifier)' == 'android' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')) ..."
    Condition=" '$(TargetPlatformIdentifier)' == 'android' and $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0')) ..."

This breaks `Xamarin.Legacy.Sdk`, as a `monoandroid12` application
would have `$(TargetFrameworkVersion)` set to `v12.0`.

The only sensible way to workaround this is to provide an Android
`AutoImport.props` in Xamarin.Legacy.Sdk. We need to do this, because
xamarin/AndroidX builds using Xamarin.Legacy.Sdk.

TBD what happens for iOS and macOS, as they have not implemented the
`Condition` in `AutoImport.props` yet in the xamarin-macios repo.