### PR TITLE
Add support for .NET 6 & 7 Android workloads

### DIFF
--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- Workaround for current .NET 6 -->
+    <UseMicrosoftAndroidSdk>true</UseMicrosoftAndroidSdk>
+  </PropertyGroup>
+</Project>

--- a/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.Android.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.Android.targets
@@ -25,7 +25,21 @@
     <TargetPlatformIdentifier>Android</TargetPlatformIdentifier>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">true</AndroidUseIntermediateDesignerFile>
   </PropertyGroup>
-  <Import Sdk="Microsoft.Android.Sdk" Project="../targets/Microsoft.Android.Sdk.DefaultProperties.targets" />
+  <Import
+      Condition=" '$(UseMicrosoftAndroidSdk)' == 'true' "
+      Sdk="Microsoft.Android.Sdk"
+      Project="../targets/Microsoft.Android.Sdk.DefaultProperties.targets"
+  />
+  <Import
+      Condition=" '$(UseMicrosoftAndroidSdk)' != 'true' and ('$(UseMicrosoftAndroidSdkNet6)' == 'true' or !$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0')))"
+      Sdk="Microsoft.Android.Sdk.net6"
+      Project="../targets/Microsoft.Android.Sdk.DefaultProperties.targets"
+  />
+  <Import
+      Condition=" '$(UseMicrosoftAndroidSdk)' != 'true' and ('$(UseMicrosoftAndroidSdkNet7)' == 'true' or $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0')))"
+      Sdk="Microsoft.Android.Sdk.net7"
+      Project="../targets/Microsoft.Android.Sdk.DefaultProperties.targets"
+  />
   <Import Project="$(_LegacyExtensionsPath)/Xamarin/Android/Xamarin.Android.CSharp.targets"   Condition=" '$(IsBindingProject)' != 'true' and '$(_FixupsNeeded)' == 'true' " />
   <Import Project="$(_LegacyExtensionsPath)/Xamarin/Android/Xamarin.Android.Bindings.targets" Condition=" '$(IsBindingProject)' == 'true' and '$(_FixupsNeeded)' == 'true' " />
   <Import Project="$(MSBuildExtensionsPath)/Xamarin/Android/Xamarin.Android.CSharp.targets"   Condition=" '$(IsBindingProject)' != 'true' and '$(_FixupsNeeded)' != 'true' " />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/7261#discussion_r954477870

To make .NET 6 builds work from a .NET 7 SDK, we are changing:

    Microsoft.Android.Sdk

To:

    Microsoft.Android.Sdk.net6
    Microsoft.Android.Sdk.net7

To deal with this in Xamarin.Legacy.Sdk, by default it will check for:

    <!--
      if we are not .NET 7 use .NET 6, so legacy or net6.0 will import
      !$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0'))
    -->
    <Import Sdk="Microsoft.Android.Sdk.net6" ... />
    <!--
      import .NET 7 if we are .NET 7
      $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0'))
    -->
    <Import Sdk="Microsoft.Android.Sdk.net7" ... />

To get the old behavior, you can set:

    <UseMicrosoftAndroidSdk>true</UseMicrosoftAndroidSdk>

Or to explicitly select, you can set one of:

    <UseMicrosoftAndroidSdkNet6>true</UseMicrosoftAndroidSdkNet6>
    <UseMicrosoftAndroidSdkNet7>true</UseMicrosoftAndroidSdkNet7>

In a future change, we can make .NET 7 the default, but likely only
after it is released GA.