### PR TITLE
Fix disc full enumeration by checking that $(MonoAndroidAssetsPrefix) is not empty string

### DIFF
--- a/src/Xamarin.Legacy.Sdk/Sdk/AutoImport.Android.props
+++ b/src/Xamarin.Legacy.Sdk/Sdk/AutoImport.Android.props
@@ -23,7 +23,7 @@ NOTE! everything must be conditioned behind:
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.ttc" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\raw\*" Exclude="$(MonoAndroidResourcePrefix)\raw\.*" />
     <!-- Default Asset file inclusion -->
-    <AndroidAsset Condition=" ('$(MonoAndroidAssetsPrefix)' != ''" Include="$(MonoAndroidAssetsPrefix)\**\*" Exclude="$(MonoAndroidAssetsPrefix)\**\.*\**" />
+    <AndroidAsset Condition=" '$(MonoAndroidAssetsPrefix)' != '' " Include="$(MonoAndroidAssetsPrefix)\**\*" Exclude="$(MonoAndroidAssetsPrefix)\**\.*\**" />
     <!-- Default XPath transforms for bindings -->
     <TransformFile Include="Transforms*.xml" />
     <TransformFile Include="Transforms\**\*.xml" />

--- a/src/Xamarin.Legacy.Sdk/Sdk/AutoImport.Android.props
+++ b/src/Xamarin.Legacy.Sdk/Sdk/AutoImport.Android.props
@@ -10,7 +10,8 @@ NOTE! everything must be conditioned behind:
     <Using Include="Android.OS.Bundle" Alias="Bundle" Platform="Android" Sdk="Xamarin.Legacy.Sdk" />
   </ItemGroup>
 
-  <ItemGroup Condition=" ('$(TargetPlatformIdentifier)' == 'android' or $(TargetFramework.StartsWith ('MonoAndroid', StringComparison.OrdinalIgnoreCase))) and '$(EnableDefaultXamarinLegacySdkItems)' == 'true' ">
+  <ItemGroup Condition=" ('$(TargetPlatformIdentifier)' == 'android' or $(TargetFramework.StartsWith ('MonoAndroid', StringComparison.OrdinalIgnoreCase))) and '$(EnableDefaultXamarinLegacySdkItems)' == 'true' 
+                        and ('$(MonoAndroidAssetsPrefix)' != '' and '$(MonoAndroidResourcePrefix)' != '') ">
     <!-- Default Resource file inclusion -->
     <!-- https://developer.android.com/guide/topics/resources/providing-resources -->
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.xml" />
@@ -23,7 +24,10 @@ NOTE! everything must be conditioned behind:
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.ttc" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\raw\*" Exclude="$(MonoAndroidResourcePrefix)\raw\.*" />
     <!-- Default Asset file inclusion -->
-    <AndroidAsset Condition=" '$(MonoAndroidAssetsPrefix)' != '' " Include="$(MonoAndroidAssetsPrefix)\**\*" Exclude="$(MonoAndroidAssetsPrefix)\**\.*\**" />
+    <AndroidAsset Include="$(MonoAndroidAssetsPrefix)\**\*" Exclude="$(MonoAndroidAssetsPrefix)\**\.*\**" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" ('$(TargetPlatformIdentifier)' == 'android' or $(TargetFramework.StartsWith ('MonoAndroid', StringComparison.OrdinalIgnoreCase))) and '$(EnableDefaultXamarinLegacySdkItems)' == 'true' ">
     <!-- Default XPath transforms for bindings -->
     <TransformFile Include="Transforms*.xml" />
     <TransformFile Include="Transforms\**\*.xml" />

--- a/src/Xamarin.Legacy.Sdk/Sdk/AutoImport.Android.props
+++ b/src/Xamarin.Legacy.Sdk/Sdk/AutoImport.Android.props
@@ -23,7 +23,7 @@ NOTE! everything must be conditioned behind:
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.ttc" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\raw\*" Exclude="$(MonoAndroidResourcePrefix)\raw\.*" />
     <!-- Default Asset file inclusion -->
-    <AndroidAsset Include="$(MonoAndroidAssetsPrefix)\**\*" Exclude="$(MonoAndroidAssetsPrefix)\**\.*\**" />
+    <AndroidAsset Condition=" ('$(MonoAndroidAssetsPrefix)' != ''" Include="$(MonoAndroidAssetsPrefix)\**\*" Exclude="$(MonoAndroidAssetsPrefix)\**\.*\**" />
     <!-- Default XPath transforms for bindings -->
     <TransformFile Include="Transforms*.xml" />
     <TransformFile Include="Transforms\**\*.xml" />

--- a/src/Xamarin.Legacy.Sdk/Xamarin.Legacy.Sdk.csproj
+++ b/src/Xamarin.Legacy.Sdk/Xamarin.Legacy.Sdk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageVersion>0.2.0-alpha2</PackageVersion>
+    <PackageVersion>0.2.0-alpha3</PackageVersion>
     <PackageType>MSBuildSdk</PackageType>
     <OutputPath>../../bin/$(Configuration)/</OutputPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
During AndroidX and GooglePlaySerivces/Firebase/MLKit builds experienced following warning (which was crashing one of  Mac boxes with running out of application memory):

```
MSBUILD : warning MSB5029: The value “\**\.*\**” of the “Exclude” attribute in element <ItemGroup> in file “/Users/moljac/.nuget/packages/xamarin.legacy.sdk/0.2.0-alpha2/Sdk/AutoImport.Android.props (26,61)” is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.
```

This PR fixes this warning by adding check for $(MonoAndroidAssetsPrefix) not being empty string.
