### PR TITLE
[android] guard against accidental `\**\*` wildcards

### DIFF
--- a/src/Xamarin.Legacy.Sdk/Sdk/AutoImport.Android.props
+++ b/src/Xamarin.Legacy.Sdk/Sdk/AutoImport.Android.props
@@ -10,7 +10,10 @@ NOTE! everything must be conditioned behind:
     <Using Include="Android.OS.Bundle" Alias="Bundle" Platform="Android" Sdk="Xamarin.Legacy.Sdk" />
   </ItemGroup>
 
-  <ItemGroup Condition=" ('$(TargetPlatformIdentifier)' == 'android' or $(TargetFramework.StartsWith ('MonoAndroid', StringComparison.OrdinalIgnoreCase))) and '$(EnableDefaultXamarinLegacySdkItems)' == 'true' ">
+  <ItemGroup Condition=" '$(MonoAndroidResourcePrefix)' != '' and
+      ('$(TargetPlatformIdentifier)' == 'android' or
+      $(TargetFramework.StartsWith ('MonoAndroid', StringComparison.OrdinalIgnoreCase))) and
+      '$(EnableDefaultXamarinLegacySdkItems)' == 'true' ">
     <!-- Default Resource file inclusion -->
     <!-- https://developer.android.com/guide/topics/resources/providing-resources -->
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\*\*.xml" />
@@ -22,8 +25,19 @@ NOTE! everything must be conditioned behind:
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.otf" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\font\*.ttc" />
     <AndroidResource Include="$(MonoAndroidResourcePrefix)\raw\*" Exclude="$(MonoAndroidResourcePrefix)\raw\.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(MonoAndroidAssetsPrefix)' != ''
+      and ('$(TargetPlatformIdentifier)' == 'android' or
+      $(TargetFramework.StartsWith ('MonoAndroid', StringComparison.OrdinalIgnoreCase))) and
+      '$(EnableDefaultXamarinLegacySdkItems)' == 'true' ">
     <!-- Default Asset file inclusion -->
     <AndroidAsset Include="$(MonoAndroidAssetsPrefix)\**\*" Exclude="$(MonoAndroidAssetsPrefix)\**\.*\**" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" ('$(TargetPlatformIdentifier)' == 'android' or
+      $(TargetFramework.StartsWith ('MonoAndroid', StringComparison.OrdinalIgnoreCase))) and
+      '$(EnableDefaultXamarinLegacySdkItems)' == 'true' ">
     <!-- Default XPath transforms for bindings -->
     <TransformFile Include="Transforms*.xml" />
     <TransformFile Include="Transforms\**\*.xml" />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/7837
Context: https://github.com/xamarin/Xamarin.Legacy.Sdk/pull/46

I ended up making this change in xamarin-android to avoid a potential issue in all .NET projects, so bringing it here as well.

In cases where the `android` workload is not installed, Xamarin.Legacy.Sdk can accidentally wildcard your entire disk:

    MSBUILD : warning MSB5029: The value “\**\.*\**” of the “Exclude” attribute in element <ItemGroup> in file “/Users/moljac/.nuget/packages/xamarin.legacy.sdk/0.2.0-alpha2/Sdk/AutoImport.Android.props (26,61)” is a wildcard that results in enumerating all files on the drive, which was likely not intended. Check that referenced properties are always defined.

Add checks that `$(MonoAndroidAssetsPrefix)` and
`$(MonoAndroidResourcePrefix)` are not blank.