### PR TITLE
[android] add .NET 8 multi-targeting support

### DIFF
--- a/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.Android.targets
+++ b/src/Xamarin.Legacy.Sdk/Sdk/Xamarin.Legacy.Android.targets
@@ -31,13 +31,18 @@
       Project="../targets/Microsoft.Android.Sdk.DefaultProperties.targets"
   />
   <Import
-      Condition=" '$(UseMicrosoftAndroidSdk)' != 'true' and ('$(UseMicrosoftAndroidSdkNet6)' == 'true' or !$([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0')))"
+      Condition=" '$(UseMicrosoftAndroidSdk)' != 'true' and ('$(UseMicrosoftAndroidSdkNet6)' == 'true' or $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '6.0')))"
       Sdk="Microsoft.Android.Sdk.net6"
       Project="../targets/Microsoft.Android.Sdk.DefaultProperties.targets"
   />
   <Import
       Condition=" '$(UseMicrosoftAndroidSdk)' != 'true' and ('$(UseMicrosoftAndroidSdkNet7)' == 'true' or $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '7.0')))"
       Sdk="Microsoft.Android.Sdk.net7"
+      Project="../targets/Microsoft.Android.Sdk.DefaultProperties.targets"
+  />
+  <Import
+      Condition=" '$(UseMicrosoftAndroidSdk)' != 'true' and ('$(UseMicrosoftAndroidSdkNet8)' == 'true' or $([MSBuild]::VersionEquals($(TargetFrameworkVersion), '8.0')))"
+      Sdk="Microsoft.Android.Sdk.net8"
       Project="../targets/Microsoft.Android.Sdk.DefaultProperties.targets"
   />
   <Import Project="$(_LegacyExtensionsPath)/Xamarin/Android/Xamarin.Android.CSharp.targets"   Condition=" '$(IsBindingProject)' != 'true' and '$(_FixupsNeeded)' == 'true' " />


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/pull/7900

After attempted removal of .NET 6 (from .NET 8), we got the build error:

    Xamarin.Legacy.Android.targets(33,3): error : Could not resolve SDK "Microsoft.Android.Sdk.net6". Exactly one of the probing messages below indicates why we could not resolve the SDK. Investigate and resolve that message to correctly specify the SDK.
    Xamarin.Legacy.Android.targets(33,3): error :   SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" returned null.
    Xamarin.Legacy.Android.targets(33,3): error :   The NuGetSdkResolver did not resolve this SDK because there was no version specified in the project or global.json.
    Xamarin.Legacy.Android.targets(33,3): error :   MSB4276: The default SDK resolver failed to resolve SDK "Microsoft.Android.Sdk.net6" because directory "/Users/runner/work/1/s/xamarin-android/bin/Release/dotnet/sdk/8.0.100-preview.3.23163.4/Sdks/Microsoft.Android.Sdk.net6/Sdk" did not exist.

Add support for the .NET 8 SDK, I am unsure how it was working at all before? It must have somehow imported the .NET 6 targets.